### PR TITLE
Use note_tweet.text for Twitter Notes/long-form content

### DIFF
--- a/api/feed-stream.js
+++ b/api/feed-stream.js
@@ -143,7 +143,7 @@ module.exports = async (req, res) => {
 
           const post = {
             username: tweet.author?.userName || username,
-            text: tweet.text,
+            text: tweet.note_tweet?.text || tweet.text,
             date,
             link: tweet.url || `https://x.com/${username}/status/${tweet.id}`,
             conversationId,

--- a/api/feed-sync.js
+++ b/api/feed-sync.js
@@ -217,7 +217,7 @@ function transformTweet(tweet) {
     id: tweet.id,
     platform: 'twitter',
     username: tweet.author?.userName,
-    text: tweet.text,
+    text: tweet.note_tweet?.text || tweet.text,
     date: new Date(tweet.createdAt).toISOString(),
     link: tweet.url || `https://x.com/${tweet.author?.userName}/status/${tweet.id}`,
     conversationId: getConversationId(tweet),

--- a/api/feed.js
+++ b/api/feed.js
@@ -112,7 +112,7 @@ module.exports = async (req, res) => {
 
           allPosts.push({
             username: tweet.author?.userName || username,
-            text: tweet.text,
+            text: tweet.note_tweet?.text || tweet.text,
             date: date.toISOString(),
             link: tweet.url || `https://x.com/${username}/status/${tweet.id}`,
             conversationId,


### PR DESCRIPTION
The Twitter API returns long-form tweet text (Notes, tweets >280 chars)
in a note_tweet.text field, while the standard text field is truncated.
Prefer note_tweet.text when available across all three feed endpoints.

https://claude.ai/code/session_01AKWwFC2uY52i3bHu1EzSH6